### PR TITLE
XS✔ ◾ Issue read is needed as well for private repos

### DIFF
--- a/.github/workflows/pr-manage-stale.yml
+++ b/.github/workflows/pr-manage-stale.yml
@@ -11,13 +11,11 @@ on:
 
 permissions:
   contents: read
+  issues: read
   pull-requests: write
 
 jobs:
   review-reminder:
-    permissions:
-      contents: read
-      pull-requests: write
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Even though we are not deleting by default, the action still reads the issues https://github.com/actions/stale

Currently failing on a private repo on a client project

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ Failing workflow on a client project

> 2. What was changed?

✏️ added Issue read permissions

> 3. Did you do pair or mob programming?

✏️ no
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
